### PR TITLE
Performance improvements

### DIFF
--- a/lib/enum.rb
+++ b/lib/enum.rb
@@ -18,34 +18,38 @@ class Enum
     end
 
     def cast(value)
-      members.find { |v| v.value == value.to_s }
+      @values[value]
     end
 
     def values
-      map(&:value).to_set
+      map(&:value)
     end
 
     def each(&block)
-      members.each(&block)
+      @members.each(&block) if defined?(@members)
     end
 
     def members
-      constants.map { |c| const_get(c) }.to_set
+      return @members if defined?(@members)
+      @members = []
     end
 
     private
 
     def new(name, value = nil, &block)
       if self == Enum
-        raise ArgumentError, "You can't add values to the abstract Enum class itself."
+        raise ArgumentError,
+          "You can't add values to the abstract Enum class itself."
       end
 
-      if constants.include?(name)
-        raise ArgumentError, "Name conflict: '#{self.name}::#{name}' is already defined."
+      if const_defined?(name)
+        raise ArgumentError,
+          "Name conflict: '#{self.name}::#{name}' is already defined."
       end
 
       if values.include?(value)
-        raise ArgumentError, "Value conflict: the value '#{value}' is defined for '#{self.cast(value).name}'."
+        raise ArgumentError,
+          "Value conflict: the value '#{value}' is defined for '#{self.cast(value).name}'."
       end
 
       member = super(name, value)
@@ -57,7 +61,11 @@ class Enum
         end
       RUBY
 
-      const_set(name, member.freeze)
+      member.freeze
+
+      const_set(name, member)
+      (@members ||= []) << member
+      (@values ||= {})[value] = member
     end
   end
 end

--- a/lib/enum.rb
+++ b/lib/enum.rb
@@ -7,13 +7,23 @@ class Enum
   alias_method :inspect, :name
 
   def initialize(name, value)
+    @short_name = name.to_s.underscore
     @name = "#{self.class.name}::#{name}"
-    @value = value || @name
+    @value = value
   end
 
   class << self
+    attr_accessor :members
+
+    def inherited(child)
+      child.instance_eval do
+        @values = {}
+        @members = []
+      end
+    end
+
     def method_missing(name, *args, **kwargs, &block)
-      return super unless name[0] == name[0].upcase
+      return super unless name[0] =~ /[A-Z]/
       new(name, *args, **kwargs, &block)
     end
 
@@ -22,21 +32,16 @@ class Enum
     end
 
     def values
-      map(&:value)
+      @values.keys
     end
 
     def each(&block)
-      @members.each(&block) if defined?(@members)
-    end
-
-    def members
-      return @members if defined?(@members)
-      @members = []
+      @members.each(&block)
     end
 
     private
 
-    def new(name, value = nil, &block)
+    def new(name, value = name, &block)
       if self == Enum
         raise ArgumentError,
           "You can't add values to the abstract Enum class itself."
@@ -47,25 +52,24 @@ class Enum
           "Name conflict: '#{self.name}::#{name}' is already defined."
       end
 
-      if values.include?(value)
+      if @values[value]
         raise ArgumentError,
           "Value conflict: the value '#{value}' is defined for '#{self.cast(value).name}'."
       end
 
-      member = super(name, value)
-      member.instance_eval(&block) if block_given?
-
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         def #{name.to_s.underscore}?
-          name.demodulize.underscore == "#{name.to_s.underscore}"
+          @short_name == "#{name.to_s.underscore}"
         end
       RUBY
 
+      member = super(name, value)
+      member.instance_eval(&block) if block_given?
       member.freeze
 
       const_set(name, member)
-      (@members ||= []) << member
-      (@values ||= {})[value] = member
+      @members << member
+      @values[value] = member
     end
   end
 end

--- a/lib/literal_enums.rb
+++ b/lib/literal_enums.rb
@@ -6,6 +6,7 @@ require "literal_enums/transitions"
 require "enum"
 
 module LiteralEnums
-  class Error < StandardError; end
-  class TransitionError < Error; end
+  Error = Module.new
+  StandardError = Class.new(StandardError) { include Error }
+  TransitionError = Class.new(StandardError) { include Error }
 end

--- a/lib/literal_enums/transitions.rb
+++ b/lib/literal_enums/transitions.rb
@@ -1,32 +1,48 @@
 module LiteralEnums
   module Transitions
     def respond_to_missing?(name, include_private = false)
-      return false if name == :transitions_to
-      valid_next_states.any? { |m| m.name.to_s.demodulize.underscore.to_sym == name }
+      case transitions_to
+      when Enum
+        transitions_to.name.to_s.demodulize.underscore.to_sym == name
+      when Array
+        transitions_to.any? { |m| m.name.to_s.demodulize.underscore.to_sym == name }
+      end
     end
 
     def method_missing(name, *args, **kwargs, &block)
-      valid_next_states.find { |m| m.name.to_s.demodulize.underscore.to_sym == name } || super
+      case transitions_to
+      when Enum
+        if transitions_to.name.to_s.demodulize.underscore.to_sym == name
+          return transitions_to
+        end
+      when Array
+        if (next_one = transitions_to.find { |m| m.name.to_s.demodulize.underscore.to_sym == name })
+          return next_one
+        end
+      end
+
+      super
     end
 
     def transition_to(new_state)
       return new_state if can_transition_to?(new_state)
 
-      raise TransitionError, "You can't transition from #{self.name} to #{new_state.name}."
+      raise TransitionError,
+        "You can't transition from #{self.name} to #{new_state.name}."
     end
 
     def can_transition_to?(new_state)
-      unless new_state.is_a?(self.class)
-        raise ArgumentError "You can only transition to another #{self.class.name}."
+      case transitions_to
+      when Enum
+        transitions_to == new_state
+      when Array
+        transitions_to.include? new_state
       end
-
-      valid_next_states.include?(new_state)
     end
 
     private
 
-    def valid_next_states
-      return Array(transitions_to) if respond_to? :transitions_to
+    def transitions_to
       []
     end
   end

--- a/test/enum_test.rb
+++ b/test/enum_test.rb
@@ -40,19 +40,19 @@ class EnumTest < Minitest::Test
   end
 
   def test_values
-    assert_equal Color.values, Set.new([
+    assert_equal Color.values, [
       "ff0000",
       "00ff00",
       "0000ff"
-    ])
+    ]
   end
 
   def test_members
-    assert_equal Color.members, Set.new([
+    assert_equal Color.members, [
       Color::Red,
       Color::Green,
       Color::Blue
-    ])
+    ]
   end
 
   def test_singleton_definition
@@ -84,7 +84,7 @@ class EnumTest < Minitest::Test
 
   def test_predicate
     assert Color::Red.red?
-    
+
     refute Color::Red.green?
     refute Color::Red.blue?
   end


### PR DESCRIPTION
Before
```
                Cast    518.327k (± 0.2%) i/s -      2.598M in   5.012406s
              Lookup     23.886M (± 0.6%) i/s -    120.990M in   5.065415s
             Members    775.036k (± 0.3%) i/s -      3.939M in   5.082299s
              Values    374.491k (± 0.2%) i/s -      1.905M in   5.085853s
```


After
```
                Cast     12.079M (± 0.2%) i/s -     61.547M in   5.095414s
              Lookup     24.132M (± 0.5%) i/s -    120.758M in   5.004239s
             Members     17.562M (± 0.4%) i/s -     87.971M in   5.009275s
              Values     10.780M (± 0.2%) i/s -     54.922M in   5.094745s
```